### PR TITLE
Updated contract.js for broken token list url

### DIFF
--- a/app/client/templates/views/contracts.js
+++ b/app/client/templates/views/contracts.js
@@ -142,7 +142,7 @@ var autoScanGetTokens = function(template) {
     );
 
     var tokenListURL =
-      'https://raw.githubusercontent.com/MyEtherWallet/ethereum-lists/master/tokens/tokens-eth.json';
+      'https://raw.githubusercontent.com/MyEtherWallet/ethereum-lists/master/dist/tokens/eth/tokens-eth.json';
 
     var accounts = _.pluck(
       EthAccounts.find()


### PR DESCRIPTION
"Auto Scan" button giving an error in Contract screen because of exists token list url already replaced by target repo owner.